### PR TITLE
Added ability to seed audit logs and headers for Partner Center.

### DIFF
--- a/src/SmartOffice.Functions/Bindings/SmartOfficeExtensionConfig.cs
+++ b/src/SmartOffice.Functions/Bindings/SmartOfficeExtensionConfig.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Partner.SmartOffice.Functions.Bindings
         /// Collection of initialized data repositories.
         /// </summary>
         private static readonly ConcurrentDictionary<string, object> Repos = new ConcurrentDictionary<string, object>();
-
+        
         /// <summary>
         /// Used to help ensure that data repositories are initialized in a thread safe manner.
         /// </summary>
@@ -160,7 +160,8 @@ namespace Microsoft.Partner.SmartOffice.Functions.Bindings
                         input.ApplicationId,
                         await vaultService.GetSecretAsync(input.SecretName).ConfigureAwait(false),
                         input.Resource,
-                        input.ApplicationTenantId));
+                        input.ApplicationTenantId),
+                    new PartnerServiceMessageHandler());
             }
             finally
             {
@@ -250,7 +251,6 @@ namespace Microsoft.Partner.SmartOffice.Functions.Bindings
         /// <param name="context">Context for the extension</param>
         public void Initialize(ExtensionConfigContext context)
         {
-
             log = context.Config.LoggerFactory.CreateLogger(LogCategories.CreateFunctionCategory("SmartOffice"));
 
             context.AddBindingRule<DataRepositoryAttribute>().BindToInput<object>(this);

--- a/src/SmartOffice.Functions/SmartOffice.Functions.csproj
+++ b/src/SmartOffice.Functions/SmartOffice.Functions.csproj
@@ -4,7 +4,13 @@
     <AzureFunctionsVersion>v2</AzureFunctionsVersion>
     <AssemblyName>Microsoft.Partner.SmartOffice.Functions</AssemblyName>
     <RootNamespace>Microsoft.Partner.SmartOffice.Functions</RootNamespace>
-    <Version>0.0.2</Version>
+    <Version>0.0.3</Version>
+    <Company>Microsoft</Company>
+    <Authors>One Commercial Partner</Authors>
+    <Product>Partner Smart Office</Product>
+    <PackageProjectUrl>https://github.com/Microsoft/Partner-Smart-Office/</PackageProjectUrl>
+    <PackageLicenseUrl>https://github.com/Microsoft/Partner-Smart-Office/blob/master/LICENSE</PackageLicenseUrl>
+    <RepositoryUrl>https://github.com/Microsoft/Partner-Smart-Office/</RepositoryUrl>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <WarningsAsErrors>NU1605</WarningsAsErrors>

--- a/src/SmartOffice.Services/PartnerCenter/PartnerServiceClient.cs
+++ b/src/SmartOffice.Services/PartnerCenter/PartnerServiceClient.cs
@@ -28,7 +28,40 @@ namespace Microsoft.Partner.SmartOffice.Services.PartnerCenter
         /// <param name="endpoint">Address of the resource being accessed.</param>
         /// <param name="credentials">Credentials used when accessing resources.</param>
         /// <param name="handlers">List of handlers from top to bottom (outer handler is the first in the list)</param>
-        public PartnerServiceClient(Uri endpoint, ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : base(handlers)
+        public PartnerServiceClient(Uri endpoint, ServiceClientCredentials credentials, params DelegatingHandler[] handlers)
+            : base(handlers)
+        {
+            Credentials = credentials;
+            Endpoint = endpoint;
+
+            AuditRecords = new AuditRecordCollectionOperations(this);
+            Customers = new CustomerCollectionOperations(this);
+            Offers = new OfferCountrySelector(this);
+
+            DeserializationSettings = new JsonSerializerSettings
+            {
+                ContractResolver = new ReadOnlyJsonContractResolver(),
+                Converters = new List<JsonConverter>
+                {
+                    {
+                        new EnumJsonConverter()
+                    }
+                },
+                DateFormatHandling = DateFormatHandling.IsoDateFormat,
+                DateTimeZoneHandling = DateTimeZoneHandling.Utc,
+                NullValueHandling = NullValueHandling.Ignore,
+                ReferenceLoopHandling = ReferenceLoopHandling.Serialize
+            };
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PartnerServiceClient" /> class.
+        /// </summary>
+        /// <param name="endpoint">Address of the resource being accessed.</param>
+        /// <param name="credentials">Credentials used when accessing resources.</param>
+        /// <param name="httpClient">The HTTP client to be used.</param>
+        public PartnerServiceClient(Uri endpoint, ServiceClientCredentials credentials, HttpClient httpClient)
+            : base(httpClient, false)
         {
             Credentials = credentials;
             Endpoint = endpoint;

--- a/src/SmartOffice.Services/PartnerCenter/PartnerServiceMessageHandler.cs
+++ b/src/SmartOffice.Services/PartnerCenter/PartnerServiceMessageHandler.cs
@@ -1,0 +1,58 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="PartnerServiceMessageHandler.cs" company="Microsoft">
+//     Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Microsoft.Partner.SmartOffice.Services.PartnerCenter
+{
+    using System;
+    using System.Net.Http;
+    using System.Net.Http.Headers;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public class PartnerServiceMessageHandler : DelegatingHandler
+    {
+        /// <summary>
+        /// Value for the accept header.
+        /// </summary>
+        private const string AcceptType = "application/json";
+
+        /// <summary>
+        /// Name of the application to be sent with each request.
+        /// </summary>
+        private const string ApplicationName = "Partner Smart Office v0.0.3";
+
+        /// <summary>
+        /// Name of the application name header. 
+        /// </summary>
+        private const string ApplicationNameHeader = "MS-PartnerCenter-Application";
+
+        /// <summary>
+        /// Name of the correlation identifier header.
+        /// </summary>
+        private const string CorrelationIdHeader = "MS-CorrelationId";
+
+        /// <summary>
+        /// Name of the request identifier header.
+        /// </summary>
+        private const string RequestIdHeader = "MS-RequestId";
+
+        /// <summary>
+        /// Sends a HTTP request to the inner handler to send to the server as an asynchronous operation.
+        /// </summary>
+        /// <param name="request">The HTTP request message to send to the server.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>The response from the HTTP operation.</returns>
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(AcceptType));
+            request.Headers.Add(ApplicationNameHeader, ApplicationName);
+            request.Headers.Add(CorrelationIdHeader, Guid.NewGuid().ToString());
+            request.Headers.Add(RequestIdHeader, Guid.NewGuid().ToString());
+
+            return base.SendAsync(request, cancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
The following changes were made with this pull request

- Added the ability to seed audit logs for new CSP environments
- All operations that invoke the Partner Center API will now have the MS-CorrelationId, MS-PartnerCenter-Application, and MS-RequestId headers