### PR TITLE
Handle audit records without CustomerId elements

### DIFF
--- a/src/SmartOffice.Functions/Environments.cs
+++ b/src/SmartOffice.Functions/Environments.cs
@@ -228,7 +228,7 @@ namespace Microsoft.Partner.SmartOffice.Functions
                         {
                             AppEndpoint = environment.AppEndpoint,
                             AuditRecords = auditRecords
-                                .Where(r => r.CustomerId.Equals(customer.Id, StringComparison.InvariantCultureIgnoreCase))
+                                .Where(r => r.CustomerId?.Equals(customer.Id, StringComparison.InvariantCultureIgnoreCase) ?? false)
                                 .ToList(),
                             Customer = customer,
                             PartnerCenterEndpoint = environment.PartnerCenterEndpoint


### PR DESCRIPTION
As summarized in my email, this fixes a small bug when processing a partner if the partner audit records contain any records without a CustomerId element. Specifically, this includes the failure audit messages for an AddCustomer record.