### PR TITLE
1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,24 @@
 # Partner Smart Office Changelog
 
+## 1.0.0 (2018-06-08)
+
+The following issues were addressed with this release
+
+- Modified the processing restrictions
+  - Maximum dequeue count is now configured to 3
+  - Maximum number of records dequeued is now configured to 14
+  - Threshold for the number of messages fetched is now configured to 7
+- When inserting a collection of records, they will be inserted in chunks. This change ensures that all records will be inserted in a timely manner.
+- When inserting a large collection of records, the request unit (RU) throughput for the collection will be dynamically increased from 500 to either 1000 or 2000. Once the collection of records has been inserted, the RUs for the collection will be reset to 500.
+
 ## 0.8.0 (2018-06-07)
 
 The following issues were addressed with this release
 
-* Added the missing properties from the Azure utilization record class.
-* Addressed issue where Azure utilization records were not getting imported correct. See issue [#27](https://github.com/Microsoft/Partner-Smart-Office/issues/27) for more information
-* Addressed issue where an exception stating messages cannot be larger than 65536 bytes might occurr. See issue [#28](https://github.com/Microsoft/Partner-Smart-Office/issues/28) for more information
-* Service address values will now default to https://graph.microsoft.com and https://api.partnercenter.microsoft.com
+- Added the missing properties from the Azure utilization record class.
+- Addressed issue where Azure utilization records were not getting imported correct. See issue [#27](https://github.com/Microsoft/Partner-Smart-Office/issues/27) for more information
+- Addressed issue where an exception stating messages cannot be larger than 65536 bytes might occurr. See issue [#28](https://github.com/Microsoft/Partner-Smart-Office/issues/28) for more information
+- Service address values will now default to <https://graph.microsoft.com> and <https://api.partnercenter.microsoft.com>
 
 ## 0.6.0 (2018-06-06)
 
@@ -15,12 +26,12 @@ As of this release, we are introducing a code freeze. This means no new configur
 
 The following enhancements were made with this release
 
-* Added logic to the *ProcessEnvironments* function to write a warning to the console if no environments have been created.
-* Modified the authentication configuration for the portal to utilize Azure AD app roles over Azure AD directory roles. This change will make it easier for organizations that are using separate Azure AD tenants for authentication to deploy the solution.
+- Added logic to the *ProcessEnvironments* function to write a warning to the console if no environments have been created.
+- Modified the authentication configuration for the portal to utilize Azure AD app roles over Azure AD directory roles. This change will make it easier for organizations that are using separate Azure AD tenants for authentication to deploy the solution.
 
 The following issues were addressed with this release
 
-* Deployment may fail with error an stating the key vault name is invalid. Pull request [#24](https://github.com/Microsoft/Partner-Smart-Office/pull/24) introduced the solution for this issue.
+- Deployment may fail with error an stating the key vault name is invalid. Pull request [#24](https://github.com/Microsoft/Partner-Smart-Office/pull/24) introduced the solution for this issue.
 
 This update will require an Azure AD application role be defined and assigned to users that will be managing environments using the portal. Users who are not assigned to this role will receive an access denied error when attempting to access the portal. If you have an existing Azure AD application that you would like to use for the portal then it is recommended that you run the following PowerShell script to create the application role
 
@@ -49,38 +60,38 @@ If you need information on how to assign users to Azure AD application roles ple
 
 The following enhancements were made with this release
 
-* Added a portal to manage the creation and settings for an environment.
-* Added the ability to synchronize Azure utilization records for Azure CSP subscriptions. This ability is controlled using the ProcessAzureUsage flag configured on each instance. The default value is false for all environments.
+- Added a portal to manage the creation and settings for an environment.
+- Added the ability to synchronize Azure utilization records for Azure CSP subscriptions. This ability is controlled using the ProcessAzureUsage flag configured on each instance. The default value is false for all environments.
 
 The following bugs were fixed with this release
 
-* A null reference exception was thrown when processing audit records that did not have a customer identifier. This has been fixed through [#19](https://github.com/Microsoft/Partner-Smart-Office/pull/19)
-* A format exception was thrown when processing security information for an EA environment. This was fixed through [#20](https://github.com/Microsoft/Partner-Smart-Office/pull/20)
+- A null reference exception was thrown when processing audit records that did not have a customer identifier. This has been fixed through [#19](https://github.com/Microsoft/Partner-Smart-Office/pull/19)
+- A format exception was thrown when processing security information for an EA environment. This was fixed through [#20](https://github.com/Microsoft/Partner-Smart-Office/pull/20)
 
 The following changes should be made to existing deployments so that the portal will function as excepted
 
-* Add the _Read Directory Data_ application permission to the application you created using the [Create-AzureADApplication.ps1](https://raw.githubusercontent.com/Microsoft/Partner-Smart-Office/master/scripts/Create-AzureADApplication.ps1) script
+- Add the _Read Directory Data_ application permission to the application you created using the [Create-AzureADApplication.ps1](https://raw.githubusercontent.com/Microsoft/Partner-Smart-Office/master/scripts/Create-AzureADApplication.ps1) script
 
 ## 0.0.3 (2018-06-01)
 
-* Added the ability to seed audit logs for CSP environments that are new to this platform.
-* Added the ability to seed Secure Score information from the past 30 days for customers that are new to this platform.
-* Added the ability to track exceptions when processing a customer. If an exception is encountered when processing a customer the entire exception will be written to the ProcessException property of the customer details object.
-* Added the environment identifier to the customer details. If you existing customer details without this property, you will need to delete the LastProcessed property from the environment collection to get the property added to the existing records.
-* Each request to the Partner Center API now includes the MS-CorrelationId, MS-PartnerCenter-ApplicationName, and MS-RequestId header
-* Fixed issue [#11](https://github.com/Microsoft/Partner-Smart-Office/issues/12)
-* Fixed issue [#12](https://github.com/Microsoft/Partner-Smart-Office/issues/12)
-* Fixed issue [#13](https://github.com/Microsoft/Partner-Smart-Office/issues/13)
+- Added the ability to seed audit logs for CSP environments that are new to this platform.
+- Added the ability to seed Secure Score information from the past 30 days for customers that are new to this platform.
+- Added the ability to track exceptions when processing a customer. If an exception is encountered when processing a customer the entire exception will be written to the ProcessException property of the customer details object.
+- Added the environment identifier to the customer details. If you existing customer details without this property, you will need to delete the LastProcessed property from the environment collection to get the property added to the existing records.
+- Each request to the Partner Center API now includes the MS-CorrelationId, MS-PartnerCenter-ApplicationName, and MS-RequestId header
+- Fixed issue [#11](https://github.com/Microsoft/Partner-Smart-Office/issues/12)
+- Fixed issue [#12](https://github.com/Microsoft/Partner-Smart-Office/issues/12)
+- Fixed issue [#13](https://github.com/Microsoft/Partner-Smart-Office/issues/13)
 
 ## 0.0.2 (2018-05-29)
 
-* Added the ability to synchronize data from multiple environments. This change makes it possible for partners with more than one Cloud Solution Provider reseller tenant to aggregate data for all customers.
-* Added the ability to synchronize more than 500 resources using the Partner Center API.
-* Added the ability to synchronize CSP subscriptions.
-* Defined processing restrictions
-  * Maximum dequeue count is now configured to 3
-  * Maximum number of records dequeued is now configured to 10
-  * Threshold for the number of messages fetched is now configured to 5
+- Added the ability to synchronize data from multiple environments. This change makes it possible for partners with more than one Cloud Solution Provider reseller tenant to aggregate data for all customers.
+- Added the ability to synchronize more than 500 resources using the Partner Center API.
+- Added the ability to synchronize CSP subscriptions.
+- Defined processing restrictions
+  - Maximum dequeue count is now configured to 3
+  - Maximum number of records dequeued is now configured to 10
+  - Threshold for the number of messages fetched is now configured to 5
 
 The following breaking changes were made with this release.
 
@@ -126,12 +137,12 @@ In a future release, there will be a portal to manage environments and review ex
 
 ## 0.0.1 (2018-05-07)
 
-* Added the ability to synchronize security alerts from the [Intelligent Security Graph](https://www.microsoft.com/en-us/security/intelligence-security-api).
-* Corrected an error with handling exceptions for HTTP service operations.
+- Added the ability to synchronize security alerts from the [Intelligent Security Graph](https://www.microsoft.com/en-us/security/intelligence-security-api).
+- Corrected an error with handling exceptions for HTTP service operations.
 
 The following breaking changes were made with this release.
 
-* Adding the ability to synchronize security alerts from the Intelligent Security Graph requires additional permissions. After deploying this update perform the following to add the required permissions
+- Adding the ability to synchronize security alerts from the Intelligent Security Graph requires additional permissions. After deploying this update perform the following to add the required permissions
 
     1. Locate the Azure AD application created, in the Azure management portal, that provides access to Microsoft Graph.
     2. Add the *Read your organization’s security events* application permission to the *Microsoft Graph* API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,15 @@
 # Partner Smart Office Changelog
 
-## 1.0.0 (2018-06-08)
+## 1.0.0 (2018-06-11)
 
 The following issues were addressed with this release
 
+- Added partitioning to select collections. Please note that this change is a **breaking** change. If you have an existing deployment you will need to delete all collections excepted for the *Environments* collection.
 - Modified the processing restrictions
   - Maximum dequeue count is now configured to 3
   - Maximum number of records dequeued is now configured to 14
   - Threshold for the number of messages fetched is now configured to 7
+- Only audit records from the pervious day will be imported for now.
 - When inserting a collection of records, they will be inserted in chunks. This change ensures that all records will be inserted in a timely manner.
 - When inserting a large collection of records, the request unit (RU) throughput for the collection will be dynamically increased from 500 to either 1000 or 2000. Once the collection of records has been inserted, the RUs for the collection will be reset to 500.
 

--- a/src/SmartOffice.Data/IDocumentRepository.cs
+++ b/src/SmartOffice.Data/IDocumentRepository.cs
@@ -17,17 +17,19 @@ namespace Microsoft.Partner.SmartOffice.Data
         /// Add or update an item in the repository.
         /// </summary>
         /// <param name="item">The item to be added or updated.</param>
+        /// <param name="partitionKey">Key used to partition the data.</param>
         /// <returns>The entity that was added or updated.</returns>
-        Task<TEntity> AddOrUpdateAsync(TEntity item);
+        Task<TEntity> AddOrUpdateAsync(TEntity item, string partitionKey = null);
 
         /// <summary>
         /// Add or update a collection of items in the repository.
         /// </summary>
         /// <param name="items">A collection of items to be added or updated.</param>
+        /// <param name="partitionKey">Key used to partition the data.</param>
         /// <returns>
         /// An instance of the <see cref="Task" /> class that represents the asynchronous operation.
         /// </returns>
-        Task AddOrUpdateAsync(IEnumerable<TEntity> items);
+        Task AddOrUpdateAsync(IEnumerable<TEntity> items, string partitionKey = null);
 
         /// <summary>
         /// Deletes the document associated with the specified identifier.
@@ -59,10 +61,11 @@ namespace Microsoft.Partner.SmartOffice.Data
         /// Gets a sequence of items for the repository that matches the query. 
         /// </summary>
         /// <param name="predicate">A function to test each element for a condition.</param>
+        /// <param name="partitionKey">Key used to partition the data.</param>
         /// <returns>
         /// A collection that contains items from the repository that satisfy the condition specified by predicate.
         /// </returns>
-        Task<List<TEntity>> GetAsync(Expression<Func<TEntity, bool>> predicate);
+        Task<List<TEntity>> GetAsync(Expression<Func<TEntity, bool>> predicate, string partitionKey);
 
         /// <summary>
         /// Performs the initialization operations for the repository.
@@ -77,6 +80,6 @@ namespace Microsoft.Partner.SmartOffice.Data
         /// </summary>
         /// <param name="item">The item to be updated.</param>
         /// <returns>The entity that updated.</returns>
-         Task<TEntity> UpdateAsync(TEntity item);
+        Task<TEntity> UpdateAsync(TEntity item);
     }
 }

--- a/src/SmartOffice.Functions/Bindings/SmartOfficeExtensionConfig.cs
+++ b/src/SmartOffice.Functions/Bindings/SmartOfficeExtensionConfig.cs
@@ -110,7 +110,8 @@ namespace Microsoft.Partner.SmartOffice.Functions.Bindings
                 return await GetRepoAsync<AuditRecord>(
                     AuditRecordsCollectionId,
                     input.CosmosDbEndpoint,
-                    input.KeyVaultEndpoint).ConfigureAwait(false);
+                    input.KeyVaultEndpoint,
+                    "/PartnerId").ConfigureAwait(false);
             }
             else if (input.DataType == typeof(ControlListEntry))
             {
@@ -138,21 +139,24 @@ namespace Microsoft.Partner.SmartOffice.Functions.Bindings
                 return await GetRepoAsync<SecureScore>(
                     SecureScoreCollectionId,
                     input.CosmosDbEndpoint,
-                    input.KeyVaultEndpoint).ConfigureAwait(false);
+                    input.KeyVaultEndpoint,
+                    "/tenantId").ConfigureAwait(false);
             }
             else if (input.DataType == typeof(SubscriptionDetail))
             {
                 return await GetRepoAsync<SubscriptionDetail>(
                     SubscriptionsCollectionId,
                     input.CosmosDbEndpoint,
-                    input.KeyVaultEndpoint).ConfigureAwait(false);
+                    input.KeyVaultEndpoint,
+                    "/tenantId").ConfigureAwait(false);
             }
             else if (input.DataType == typeof(UtilizationDetail))
             {
                 return await GetRepoAsync<UtilizationDetail>(
                     UtilizationCollectId,
                     input.CosmosDbEndpoint,
-                    input.KeyVaultEndpoint).ConfigureAwait(false);
+                    input.KeyVaultEndpoint,
+                    "/subscriptionId").ConfigureAwait(false);
             }
 
             throw new Exception($"Invalid data type of {input.DataType} specified.");
@@ -275,7 +279,8 @@ namespace Microsoft.Partner.SmartOffice.Functions.Bindings
         private static async Task<IDocumentRepository<TEntity>> GetRepoAsync<TEntity>(
             string collectionId,
             string cosmosDbEndpoint,
-            string keyVaultEndpoint) where TEntity : class
+            string keyVaultEndpoint,
+            string partitionKey = null) where TEntity : class
         {
             DocumentRepository<TEntity> repo;
             KeyVaultService keyVault;
@@ -294,7 +299,8 @@ namespace Microsoft.Partner.SmartOffice.Functions.Bindings
                         cosmosDbEndpoint,
                         authKey,
                         DatabaseId,
-                        collectionId);
+                        collectionId,
+                        partitionKey);
 
                     await repo.InitializeAsync().ConfigureAwait(false);
 

--- a/src/SmartOffice.Functions/Environments.cs
+++ b/src/SmartOffice.Functions/Environments.cs
@@ -230,12 +230,12 @@ namespace Microsoft.Partner.SmartOffice.Functions
 
                 auditRecords = await GetAuditRecordsAsyc(
                     partner,
-                    DateTime.UtcNow.AddDays(-days),
+                    DateTime.UtcNow.AddDays(-1),
                     DateTime.UtcNow).ConfigureAwait(false);
 
                 if (auditRecords.Count > 0)
                 {
-                    log.Info($"Importing {auditRecords.Count} audit records from the past {days} days.");
+                    log.Info($"Importing {auditRecords.Count} audit records available between now and the pervious day.");
 
                     // Add, or update, each audit record to the database.
                     await auditRecordRepository.AddOrUpdateAsync(

--- a/src/SmartOffice.Functions/Environments.cs
+++ b/src/SmartOffice.Functions/Environments.cs
@@ -95,7 +95,9 @@ namespace Microsoft.Partner.SmartOffice.Functions
                     try
                     {
                         customerDetail.Customer.ProcessException = null;
-                        subscriptions = await GetSubscriptionsAsync(partner, customerDetail.Customer.Id).ConfigureAwait(false);
+                        subscriptions = await GetSubscriptionsAsync(
+                            partner,
+                            customerDetail.Customer.Id).ConfigureAwait(false);
                     }
                     catch (ServiceClientException ex)
                     {
@@ -108,8 +110,10 @@ namespace Microsoft.Partner.SmartOffice.Functions
                 else
                 {
                     // Obtain a list of audit records for the specified customer that happened since the customer was last processed.
-                    auditRecords = await auditRecordRepository.GetAsync(r => r.CustomerId == customerDetail.Customer.Id
-                        && r.OperationDate >= customerDetail.Customer.LastProcessed).ConfigureAwait(false);
+                    auditRecords = await auditRecordRepository.GetAsync(
+                        r => r.CustomerId == customerDetail.Customer.Id
+                            && r.OperationDate >= customerDetail.Customer.LastProcessed,
+                        customerDetail.Customer.EnvironmentId).ConfigureAwait(false);
 
                     // Since the period is less than 30 we can utilize the audit logs to reconstruct any subscriptions that were created.
                     subscriptions = await BuildUsingAuditRecordsAsync(
@@ -121,7 +125,9 @@ namespace Microsoft.Partner.SmartOffice.Functions
 
                 if (subscriptions?.Count > 0)
                 {
-                    await subscriptionRepository.AddOrUpdateAsync(subscriptions).ConfigureAwait(false);
+                    await subscriptionRepository.AddOrUpdateAsync(
+                        subscriptions,
+                        customerDetail.Customer.Id).ConfigureAwait(false);
                 }
 
                 if (customerDetail.Customer.ProcessException == null)
@@ -232,7 +238,9 @@ namespace Microsoft.Partner.SmartOffice.Functions
                     log.Info($"Importing {auditRecords.Count} audit records from the past {days} days.");
 
                     // Add, or update, each audit record to the database.
-                    await auditRecordRepository.AddOrUpdateAsync(auditRecords).ConfigureAwait(false);
+                    await auditRecordRepository.AddOrUpdateAsync(
+                        auditRecords,
+                        environment.Id).ConfigureAwait(false);
                 }
 
                 if (days >= 30)
@@ -323,13 +331,17 @@ namespace Microsoft.Partner.SmartOffice.Functions
             if (scores?.Count > 0)
             {
                 log.Info($"Importing {scores.Count} Secure Score entries for {data.Customer.Id}");
-                await secureScoreRepository.AddOrUpdateAsync(scores).ConfigureAwait(false);
+                await secureScoreRepository.AddOrUpdateAsync(
+                    scores,
+                    data.Customer.Id).ConfigureAwait(false);
             }
 
             if (alerts?.Count > 0)
             {
                 log.Info($"Importing {alerts.Count} security alert entries for {data.Customer.Id}");
-                await securityAlertRepository.AddOrUpdateAsync(alerts).ConfigureAwait(false);
+                await securityAlertRepository.AddOrUpdateAsync(
+                    alerts,
+                    data.Customer.Id).ConfigureAwait(false);
             }
 
             log.Info($"Successfully process data for {data.Customer.Id}");
@@ -406,7 +418,9 @@ namespace Microsoft.Partner.SmartOffice.Functions
                 {
                     log.Info($"Writing {records.Count} utilization records to the repository.");
 
-                    await repository.AddOrUpdateAsync(records).ConfigureAwait(false);
+                    await repository.AddOrUpdateAsync(
+                        records,
+                        subscriptionDetail.Subscription.Id).ConfigureAwait(false);
                 }
             }
             finally
@@ -576,7 +590,7 @@ namespace Microsoft.Partner.SmartOffice.Functions
                     .OrderBy(r => r.OperationDate);
 
                 resources = await repository
-                    .GetAsync(r => r.TenantId == customer.Id)
+                    .GetAsync(r => r.TenantId == customer.Id, customer.Id)
                     .ConfigureAwait(false);
 
                 foreach (AuditRecord record in filteredRecords)

--- a/src/SmartOffice.Functions/SmartOffice.Functions.csproj
+++ b/src/SmartOffice.Functions/SmartOffice.Functions.csproj
@@ -24,7 +24,7 @@
     <EmbeddedResource Include="Assets\SecureScoreControlsList.csv" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CsvHelper" Version="7.1.0" />
+    <PackageReference Include="CsvHelper" Version="7.1.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.13" />
   </ItemGroup>

--- a/src/SmartOffice.Functions/host.json
+++ b/src/SmartOffice.Functions/host.json
@@ -2,8 +2,8 @@
   "queues": {
     "maxPollingInterval": 2000,
     "visibilityTimeout": "00:00:30",
-    "batchSize": 10,
+    "batchSize": 14,
     "maxDequeueCount": 3,
-    "newBatchThreshold": 5
+    "newBatchThreshold": 7
   }
 }

--- a/src/SmartOffice.Models/UtilizationDetail.cs
+++ b/src/SmartOffice.Models/UtilizationDetail.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Partner.SmartOffice.Models
         /// <summary>
         /// Gets or sets the key-value pairs of instance-level details.
         /// </summary>
+        [JsonProperty("infoFields")]
         public IDictionary<string, string> InfoFields { get; set; }
 
         /// <summary>
@@ -27,42 +28,50 @@ namespace Microsoft.Partner.SmartOffice.Models
         /// <summary>
         /// Gets or sets the instance details.
         /// </summary>
+        [JsonProperty("instanceData")]
         public AzureInstanceData InstanceData { get; set; }
 
         /// <summary>
         /// Gets or sets the quantity consumed of the Azure resource.
         /// </summary>
+        [JsonProperty("quantity")]
         public decimal Quantity { get; set; }
 
         /// <summary>
         /// Gets or sets the Azure resource which was used.
         /// </summary>
+        [JsonProperty("resource")]
         public AzureResource Resource { get; set; }
 
         /// <summary>
         /// Gets or sets the identifier of the subscription that owns the usage.
         /// </summary>
+        [JsonProperty("subscriptionId")]
         public string SubscriptionId { get; set; }
 
         /// <summary>
         /// Gets or sets the tenant identifier that owns the subscription.
         /// </summary>
+        [JsonProperty("tenantId")]
         public string TenantId { get; set; }
 
         /// <summary>
         /// Gets or sets the type of quantity (hours, bytes, etc...).
         /// </summary>
+        [JsonProperty("unit")]
         public string Unit { get; set; }
 
         /// <summary>
         /// Gets or sets the end of the usage aggregation time range.
         /// The response is grouped by the time of consumption (when the resource was actually used VS. when was it reported to the billing system).
         /// </summary>
+        [JsonProperty("usageEndTime")]
         public DateTimeOffset UsageEndTime { get; set; }
 
         /// Gets or sets the start of the usage aggregation time range.
         /// The response is grouped by the time of consumption (when the resource was actually used VS. when was it reported to the billing system).
         /// </summary>
+        [JsonProperty("usageStartTime")]
         public DateTimeOffset UsageStartTime { get; set; }
     }
 }


### PR DESCRIPTION
# Description

With the pull request the following changes were made 

- Added partitioning to select collections. Please note that this change is a **breaking** change. If you have an existing deployment you will need to delete all collections excepted for the *Environments* collection.
- Modified the processing restrictions
  - Maximum dequeue count is now configured to 3
  - Maximum number of records dequeued is now configured to 14
  - Threshold for the number of messages fetched is now configured to 7
- Only audit records from the pervious day will be imported for now.
- When inserting a collection of records, they will be inserted in chunks. This change ensures that all records will be inserted in a timely manner.
- When inserting a large collection of records, the request unit (RU) throughput for the collection will be dynamically increased from 500 to either 1000 or 2000. Once the collection of records has been inserted, the RUs for the collection will be reset to 500.