### PR TITLE
Added guard code to handle AddCustomer in AuditRecordConverter

### DIFF
--- a/src/SmartOffice.Functions/Converters/AuditRecordConverter.cs
+++ b/src/SmartOffice.Functions/Converters/AuditRecordConverter.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Partner.SmartOffice.Functions.Converters
                                 resource,
                                 additionalInfo));
                     }
-                    else
+                    else if(control != null)
                     {
                         control.RemovedFromPartnerCenter = false;
                     }


### PR DESCRIPTION
# Description

I added guard code to handle an AddCustomer, avoids NullRef exception when trying to assign the RemovedFromPartnerCenter flag to a non-existent customer.

## Related issue

Kindly link any related issues (e.g. Fixes #xyz).