### PR TITLE
Updated to support Azure Functions V2

### DIFF
--- a/src/SmartOffice.Functions/host.json
+++ b/src/SmartOffice.Functions/host.json
@@ -1,9 +1,12 @@
 {
-  "queues": {
-    "maxPollingInterval": 2000,
-    "visibilityTimeout": "00:00:30",
-    "batchSize": 10,
-    "maxDequeueCount": 3,
-    "newBatchThreshold": 5
-  }
+    "version": "2.0",
+    "extensions": {
+        "queues": {
+            "maxPollingInterval": 2000,
+    	    "visibilityTimeout": "00:00:30",
+            "batchSize": 10,
+            "maxDequeueCount": 3,
+            "newBatchThreshold": 5
+      }
+   }
 }


### PR DESCRIPTION
Updated to resolve error 'The function runtime is unable to start.' when trying to run PullEnvironments Function manually.

The host.json file was missing the required 'version' property. Have updated to V2 to include the missing version 2.0 property  and as per the V2 specifications have moved the application-level extension settings into "extensions"

Refer to
https://aka.ms/functions-hostjson
