### PR TITLE
Fixed Issue using $App.ID instead of $App.AppID

### DIFF
--- a/scripts/Deploy-PartnerSmartOffice.ps1
+++ b/scripts/Deploy-PartnerSmartOffice.ps1
@@ -167,4 +167,4 @@ $ResourceGroup = Read-Host -Prompt "Specify a resource group name"
 Write-Host -ForegroundColor Green "Deploying Partner Smart Office. Please note this process can take several minutes."
 
 New-AzureRmResourceGroup -Location southcentralus -Name $ResourceGroup
-New-AzureRmResourceGroupDeployment -Name $(New-Guid).ToString() -ResourceGroupName $ResourceGroup -TemplateUri https://raw.githubusercontent.com/Microsoft/Partner-Smart-Office/master/azuredeploy.json -appName $appName -applicationId $app.Id
+New-AzureRmResourceGroupDeployment -Name $(New-Guid).ToString() -ResourceGroupName $ResourceGroup -TemplateUri https://raw.githubusercontent.com/Microsoft/Partner-Smart-Office/master/azuredeploy.json -appName $appName -applicationId $app.AppId


### PR DESCRIPTION
$App.ID does not exist, instead it is $App.AppID. This was incorrect on the line that calls New-AzureRmResourceGroupDeployment

# Description

$App.ID does not exist, instead it is $App.AppID. This was incorrect on the line that calls New-AzureRmResourceGroupDeployment

## Related issue

Kindly link any related issues (e.g. Fixes #xyz).